### PR TITLE
Implement `personal_sign` request

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `headless-web3-provider` library emulates a Web3 wallet similar to Metamask 
 | eth_getTransactionReceipt   | No          |
 | eth_chainId                 | No          |
 | net_version                 | No          |
+| personal_sign               | Yes         |
 
 
 ## Examples

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers'
 import { IWeb3Provider } from './types'
 import { EventEmitter } from './EventEmitter'
-import { Web3ProviderBackend } from './Web3ProviderBackend'
+import { Web3ProviderBackend, Web3ProviderConfig } from './Web3ProviderBackend'
 
 type Fn = (...args: any[]) => any
 
@@ -12,12 +12,13 @@ export function makeHeadlessWeb3Provider(
   evaluate: <T extends keyof IWeb3Provider>(
     method: T,
     ...args: IWeb3Provider[T] extends Fn ? Parameters<IWeb3Provider[T]> : []
-  ) => Promise<void> = async () => {}
+  ) => Promise<void> = async () => {},
+  config?: Web3ProviderConfig 
 ) {
   const chainRpc = new ethers.providers.JsonRpcProvider(rpcUrl, chainId)
   const web3Provider = new Web3ProviderBackend(privateKeys, [
     { chainId, rpcUrl },
-  ])
+  ], config)
 
   relayEvents(web3Provider, evaluate)
 

--- a/src/playwright.ts
+++ b/src/playwright.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test'
 import { makeHeadlessWeb3Provider } from './factory'
 import { IWeb3Provider } from './types'
+import { Web3ProviderConfig } from './Web3ProviderBackend'
 
 type Fn = (...args: any[]) => any
 
@@ -14,7 +15,8 @@ export async function injectHeadlessWeb3Provider(
   page: Page,
   privateKeys: string[],
   chainId: number,
-  chainRpcUrl: string
+  chainRpcUrl: string,
+  config?: Web3ProviderConfig
 ) {
   const evaluate = async <T extends keyof IWeb3Provider>(
     method: T,
@@ -38,7 +40,8 @@ export async function injectHeadlessWeb3Provider(
     privateKeys,
     chainId,
     chainRpcUrl,
-    evaluate
+    evaluate,
+    config
   )
 
   await page.exposeFunction(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,4 +4,5 @@ export enum Web3RequestKind {
   SendTransaction = 'eth_sendTransaction',
   SwitchEthereumChain = 'wallet_switchEthereumChain',
   AddEthereumChain = 'wallet_addEthereumChain',
+  SignMessage = 'personal_sign',
 }


### PR DESCRIPTION
This allows to Sign Message, in a way that is compatible with metamask

additional changes
- ability to enable debug logging from the Playwright test
- fix issue with `wallet_switchEthereumChain`, do not ask for authorization if current chainId matches requested
- expose pending requests info with `getPendingRequests` (for debugging mostly)