### PR TITLE
Add support for `wallet_requestPermissions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The `headless-web3-provider` library emulates a Web3 wallet similar to Metamask 
 | eth_sendTransaction        | Yes         |
 | wallet_addEthereumChain    | Yes         |
 | wallet_switchEthereumChain | Yes         |
+| wallet_requestPermissions  | Yes         |
 | personal_sign              | Yes         |
 | eth_signTypedData          | Yes         |
 | eth_signTypedData_v1       | Yes         |

--- a/src/Web3ProviderBackend.ts
+++ b/src/Web3ProviderBackend.ts
@@ -145,6 +145,16 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
         })
       }
 
+      case 'wallet_requestPermissions': {
+        if (params.length === 0 || params[0].eth_accounts === undefined) {
+          throw Deny()
+        }
+
+        return this.waitAuthorization({ method, params }, async () => {
+          return [{ parentCapability: 'eth_accounts' }]
+        })
+      }
+
       case 'personal_sign': {
         return this.waitAuthorization({ method, params }, async () => {
           const wallet = this.#getCurrentWallet()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ export enum Web3RequestKind {
   SendTransaction = 'eth_sendTransaction',
   SwitchEthereumChain = 'wallet_switchEthereumChain',
   AddEthereumChain = 'wallet_addEthereumChain',
+  RequestPermissions = 'wallet_requestPermissions',
   SignMessage = 'personal_sign',
   SignTypedData = 'eth_signTypedData',
   SignTypedDataV1 = 'eth_signTypedData_v1',

--- a/tests/e2e/metamask.spec.ts
+++ b/tests/e2e/metamask.spec.ts
@@ -69,6 +69,25 @@ test('switch a new network', async ({ page }) => {
   expect(prevChainId).not.toEqual(newChainId)
 })
 
+test('request permissions', async ({ page, accounts }) => {
+  await page.locator('text=Connect').click()
+  await wallet.authorize(Web3RequestKind.RequestAccounts)
+
+  // Request permissions
+  await page.locator('text=Request Permissions').click()
+
+  expect(
+    wallet.getPendingRequestCount(Web3RequestKind.RequestPermissions)
+  ).toEqual(1)
+
+  // You can either authorize or reject the request
+  await wallet.authorize(Web3RequestKind.RequestPermissions)
+
+  expect(
+    wallet.getPendingRequestCount(Web3RequestKind.RequestPermissions)
+  ).toEqual(0)
+})
+
 test('deploy a token', async ({ page }) => {
   await page.locator('text=Connect').click()
   await wallet.authorize(Web3RequestKind.RequestAccounts)


### PR DESCRIPTION
Added support for the missing `wallet_requestPermissions` based on [EIP-2255 ](https://eips.ethereum.org/EIPS/eip-2255).

This is useful to mimic the [MetaMask popup](https://docs.metamask.io/wallet/reference/rpc-api/#wallet_requestpermissions) in the test.

After calling `await wallet.authorize(Web3RequestKind.RequestPermissions)`, `await wallet.changeAccounts(...)` can be called to simulate the user adding or removing connected account in the MetaMask popup.
