### PR TITLE
Fix `eth_accounts` behaviour

### DIFF
--- a/tests/e2e/metamask.spec.ts
+++ b/tests/e2e/metamask.spec.ts
@@ -15,6 +15,12 @@ test.beforeEach(async ({ page, injectWeb3Provider }) => {
 })
 
 test('connect the wallet', async ({ page, accounts }) => {
+ // Until the wallet is connected, the accounts should be empty
+ let ethAccounts = await page.evaluate(() =>
+      window.ethereum.request({ method: 'eth_accounts', params: [] })
+  );
+  expect(ethAccounts).toEqual([]);
+
   // Request connecting the wallet
   await page.locator('text=Connect').click()
 
@@ -32,6 +38,12 @@ test('connect the wallet', async ({ page, accounts }) => {
   // Verify if the wallet is really connected
   await expect(page.locator('text=Connected')).toBeVisible()
   await expect(page.locator('text=' + accounts[0])).toBeVisible()
+
+  // After connecting the wallet, the accounts should be available
+  ethAccounts = await page.evaluate(() =>
+    window.ethereum.request({ method: 'eth_accounts', params: [] })
+  );
+  expect(ethAccounts).toEqual(accounts);
 })
 
 test('add a new network', async ({ page }) => {


### PR DESCRIPTION
In the current implementation, an `eth_accounts` call is blocking until the "user unlock its wallet" (aka `await wallet.authorize(Web3RequestKind.RequestAccounts)` is called). This may break fully working dApps. To mimic MetaMask and other wallets, `eth_accounts` should return an empty list of wallet until the user unlock its wallet. 

Also the `accountsChanged` event should be emitted when the user unlock the wallet (since we are going from an empty list of wallets to a non-empty list).

Thanks!