### PR TITLE
Return lowercase accounts instead of the checksummed

### DIFF
--- a/src/Web3ProviderBackend.ts
+++ b/src/Web3ProviderBackend.ts
@@ -327,7 +327,7 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
     this.#wallets = privateKeys.map((key) => new ethers.Wallet(key))
     this.emit(
       'accountsChanged',
-      await Promise.all(this.#wallets.map(async (wallet) => (await wallet.getAddress()).toLowerCase())
+      await Promise.all(this.#wallets.map(async (wallet) => (await wallet.getAddress()).toLowerCase()))
     )
   }
 

--- a/src/Web3ProviderBackend.ts
+++ b/src/Web3ProviderBackend.ts
@@ -327,7 +327,7 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
     this.#wallets = privateKeys.map((key) => new ethers.Wallet(key))
     this.emit(
       'accountsChanged',
-      await Promise.all(this.#wallets.map((wallet) => wallet.getAddress()))
+      await Promise.all(this.#wallets.map(async (wallet) => (await wallet.getAddress()).toLowerCase())
     )
   }
 

--- a/src/Web3ProviderBackend.ts
+++ b/src/Web3ProviderBackend.ts
@@ -94,7 +94,9 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
         return this.waitAuthorization(
           { method, params },
           async () => {
-            const accounts = await Promise.all(this.#wallets.map((wallet) => wallet.getAddress()))
+            const accounts = await Promise.all(
+              this.#wallets.map(async (wallet) => (await wallet.getAddress()).toLowerCase())
+            )
             this.emit('accountsChanged', accounts)
             return accounts
           },
@@ -104,7 +106,9 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
 
       case 'eth_accounts': {
         if (this._authorizedRequests['eth_requestAccounts']) {
-          return await Promise.all(this.#wallets.map((wallet) => wallet.getAddress()))
+          return await Promise.all(
+            this.#wallets.map(async (wallet) => (await wallet.getAddress()).toLowerCase())
+          )
         }
         return []
       }

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -17,7 +17,7 @@ export const test = base.extend<{
   ],
 
   accounts: async ({ signers }, use) => {
-    await use(signers.map((k) => new ethers.Wallet(k).address))
+    await use(signers.map((k) => new ethers.Wallet(k).address.toLowerCase()))
   },
 
   injectWeb3Provider: async ({ page, signers }, use) => {


### PR DESCRIPTION
I found something different behavior between MetaMask (10.34.3) and this library on writing E2E tests. Not sure which one is better between the lowercase and the checksummed though I just thought that it would be good to be equal to MetaMask behavior.

e.g.

**Headless Web3 Provider**

```
0x5D0af8790F21375C65A75C3822d75fEe75BfC649
```


**MetaMask (10.34.3)**

```
0x5d0af8790f21375c65a75c3822d75fee75bfc649
```