### PR TITLE
Emits `accountsChanged` on `wallet_requestPermissions` is approved

### DIFF
--- a/src/Web3ProviderBackend.ts
+++ b/src/Web3ProviderBackend.ts
@@ -155,6 +155,10 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
         }
 
         return this.waitAuthorization({ method, params }, async () => {
+          const accounts = await Promise.all(
+            this.#wallets.map(async (wallet) => (await wallet.getAddress()).toLowerCase())
+          )
+          this.emit('accountsChanged', accounts)
           return [{ parentCapability: 'eth_accounts' }]
         })
       }

--- a/tests/e2e/metamask.spec.ts
+++ b/tests/e2e/metamask.spec.ts
@@ -98,6 +98,11 @@ test('request permissions', async ({ page, accounts }) => {
   expect(
     wallet.getPendingRequestCount(Web3RequestKind.RequestPermissions)
   ).toEqual(0)
+
+  const ethAccounts = await page.evaluate(() =>
+    window.ethereum.request({ method: 'eth_accounts', params: [] })
+  );
+  expect(ethAccounts).toEqual(accounts);
 })
 
 test('deploy a token', async ({ page }) => {


### PR DESCRIPTION
I found MetaMask emits `accountsChanged` on `wallet_requestPermissions` is approved so I think it would be better to have the same behavior. Of course it should emit on actually accounts are changed but for this emulator is good enough at the moment so I think it could be more sophisticated with accounts are changed as a follow-up later.