### PR TITLE
Refactor rest JSON-RPC methods

### DIFF
--- a/src/Web3ProviderBackend.ts
+++ b/src/Web3ProviderBackend.ts
@@ -8,10 +8,7 @@ import {
   tap,
 } from 'rxjs'
 import { ethers, Wallet } from 'ethers'
-import {
-  createAsyncMiddleware,
-  type JsonRpcEngine,
-} from '@metamask/json-rpc-engine'
+import { type JsonRpcEngine } from '@metamask/json-rpc-engine'
 import type { JsonRpcRequest } from '@metamask/utils'
 
 import { Web3RequestKind } from './utils'
@@ -21,7 +18,6 @@ import {
   Disconnected,
   ErrorWithCode,
   Unauthorized,
-  UnsupportedMethod,
 } from './errors'
 import { ChainConnection, IWeb3Provider, PendingRequest } from './types'
 import { EventEmitter } from './EventEmitter'
@@ -67,15 +63,6 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
       waitAuthorization: (req, task) => this.waitAuthorization(req, task),
       wps: this.#wps,
     })
-    this.#engine.push(
-      createAsyncMiddleware(async (req, res, next) => {
-        try {
-          res.result = await this._request(req)
-        } catch (err) {
-          res.error = err as any
-        }
-      })
-    )
   }
 
   async request(req: Pick<JsonRpcRequest, 'method' | 'params'>): Promise<any> {
@@ -90,10 +77,6 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
     } else {
       throw res.error
     }
-  }
-
-  async _request(req: JsonRpcRequest): Promise<any> {
-    throw UnsupportedMethod()
   }
 
   #getCurrentWallet(): ethers.Signer {

--- a/src/Web3ProviderBackend.ts
+++ b/src/Web3ProviderBackend.ts
@@ -93,30 +93,7 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
   }
 
   async _request(req: JsonRpcRequest): Promise<any> {
-    switch (req.method) {
-      // todo: use the Wallet Permissions System (WPS) to handle method
-      case 'wallet_requestPermissions': {
-        if (
-          // @ts-expect-error todo: parse params
-          req.params.length === 0 ||
-          // @ts-expect-error todo: parse params
-          req.params[0].eth_accounts === undefined
-        ) {
-          throw Deny()
-        }
-
-        const accounts = await Promise.all(
-          this.#wallets.map(async (wallet) =>
-            (await wallet.getAddress()).toLowerCase()
-          )
-        )
-        this.emit('accountsChanged', accounts)
-        return [{ parentCapability: 'eth_accounts' }]
-      }
-
-      default:
-        throw UnsupportedMethod()
-    }
+    throw UnsupportedMethod()
   }
 
   #getCurrentWallet(): ethers.Signer {

--- a/src/Web3ProviderBackend.ts
+++ b/src/Web3ProviderBackend.ts
@@ -94,21 +94,6 @@ export class Web3ProviderBackend extends EventEmitter implements IWeb3Provider {
 
   async _request(req: JsonRpcRequest): Promise<any> {
     switch (req.method) {
-      case 'eth_sendTransaction': {
-        const wallet = this.#getCurrentWallet()
-        const rpc = this.getRpc()
-        // @ts-expect-error todo: parse params
-        const jsonRpcTx = req.params[0]
-
-        const txRequest = convertJsonRpcTxToEthersTxRequest(jsonRpcTx)
-        try {
-          const tx = await wallet.connect(rpc).sendTransaction(txRequest)
-          return tx.hash
-        } catch (err) {
-          throw err
-        }
-      }
-
       // todo: use the Wallet Permissions System (WPS) to handle method
       case 'wallet_requestPermissions': {
         if (
@@ -289,51 +274,4 @@ function without<T>(list: T[], item: T): T[] {
     return list.slice(0, idx).concat(list.slice(idx + 1))
   }
   return list
-}
-
-// Allowed keys for a JSON-RPC transaction as defined in:
-// https://ethereum.github.io/execution-apis/api-documentation/
-const allowedTransactionKeys = [
-  'accessList',
-  'chainId',
-  'data',
-  'from',
-  'gas',
-  'gasPrice',
-  'maxFeePerGas',
-  'maxPriorityFeePerGas',
-  'nonce',
-  'to',
-  'type',
-  'value',
-]
-
-// Convert a JSON-RPC transaction to an ethers.js transaction.
-// The reverse of this function can be found in the ethers.js library:
-// https://github.com/ethers-io/ethers.js/blob/v5.7.2/packages/providers/src.ts/json-rpc-provider.ts#L701
-function convertJsonRpcTxToEthersTxRequest(tx: {
-  [key: string]: any
-}): ethers.providers.TransactionRequest {
-  const result: any = {}
-
-  allowedTransactionKeys.forEach((key) => {
-    if (tx[key] == null) {
-      return
-    }
-
-    switch (key) {
-      // gasLimit is referred to as "gas" in JSON-RPC
-      case 'gas':
-        result['gasLimit'] = tx[key]
-        return
-      // ethers.js expects `chainId` and `type` to be a number
-      case 'chainId':
-      case 'type':
-        result[key] = Number(tx[key])
-        return
-      default:
-        result[key] = tx[key]
-    }
-  })
-  return result
 }

--- a/src/jsonRpcEngine.ts
+++ b/src/jsonRpcEngine.ts
@@ -9,6 +9,7 @@ import { WalletPermissionSystem } from './wallet/WalletPermissionSystem'
 import { makeSignMessageMiddleware } from './wallet/SignMessageMiddleware'
 import { makeNetworkMiddleware } from './wallet/NetworkMiddleware'
 import { makeTransactionMiddleware } from './wallet/TransactionMiddleware'
+import { makePermissionMiddleware } from './wallet/PermissionMiddleware'
 
 export function makeRpcEngine({
   addNetwork,
@@ -53,6 +54,7 @@ export function makeRpcEngine({
     makeNetworkMiddleware(currentChainThunk, addNetwork, switchNetwork)
   )
   engine.push(makeTransactionMiddleware(providerThunk, walletThunk))
+  engine.push(makePermissionMiddleware(emit, walletsThunk))
   engine.push(makePassThroughMiddleware(providerThunk))
 
   return engine

--- a/src/jsonRpcEngine.ts
+++ b/src/jsonRpcEngine.ts
@@ -1,6 +1,7 @@
 import { JsonRpcEngine } from '@metamask/json-rpc-engine'
 import type { JsonRpcRequest } from '@metamask/utils'
 import type { ethers } from 'ethers'
+import { UnsupportedMethod } from './errors'
 import type { ChainConnection } from './types'
 import { makePassThroughMiddleware } from './wallet/PassthroughMiddleware'
 import { makeAuthorizeMiddleware } from './wallet/AuthorizeMiddleware'
@@ -56,6 +57,11 @@ export function makeRpcEngine({
   engine.push(makeTransactionMiddleware(providerThunk, walletThunk))
   engine.push(makePermissionMiddleware(emit, walletsThunk))
   engine.push(makePassThroughMiddleware(providerThunk))
+
+  // Catch unhandled methods
+  engine.push((req, res, next, end) => {
+    end(UnsupportedMethod())
+  })
 
   return engine
 }

--- a/src/jsonRpcEngine.ts
+++ b/src/jsonRpcEngine.ts
@@ -1,26 +1,34 @@
 import { JsonRpcEngine } from '@metamask/json-rpc-engine'
 import type { JsonRpcRequest } from '@metamask/utils'
 import type { ethers } from 'ethers'
+import type { ChainConnection } from './types'
 import { makePassThroughMiddleware } from './wallet/PassthroughMiddleware'
 import { makeAuthorizeMiddleware } from './wallet/AuthorizeMiddleware'
 import { makeAccountsMiddleware } from './wallet/AccountsMiddleware'
 import { WalletPermissionSystem } from './wallet/WalletPermissionSystem'
 import { makeSignMessageMiddleware } from './wallet/SignMessageMiddleware'
+import { makeNetworkMiddleware } from './wallet/NetworkMiddleware'
 
 export function makeRpcEngine({
+  addNetwork,
+  currentChainThunk,
   debug,
   logger,
   emit,
   providerThunk,
+  switchNetwork,
   walletThunk,
   walletsThunk,
   waitAuthorization,
   wps,
 }: {
+  addNetwork: (chainId: number, rpcUrl: string) => void
+  currentChainThunk: () => ChainConnection
   debug?: boolean
   emit: (eventName: string, ...args: any[]) => void
   logger?: (message: string) => void
   providerThunk: () => ethers.providers.JsonRpcProvider
+  switchNetwork: (chainId_: number) => void
   walletThunk: () => ethers.Wallet
   walletsThunk: () => ethers.Signer[]
   waitAuthorization: (
@@ -40,6 +48,9 @@ export function makeRpcEngine({
   engine.push(makeAuthorizeMiddleware(waitAuthorization))
   engine.push(makeAccountsMiddleware(emit, walletsThunk, wps))
   engine.push(makeSignMessageMiddleware(walletThunk))
+  engine.push(
+    makeNetworkMiddleware(currentChainThunk, addNetwork, switchNetwork)
+  )
   engine.push(makePassThroughMiddleware(providerThunk))
 
   return engine

--- a/src/jsonRpcEngine.ts
+++ b/src/jsonRpcEngine.ts
@@ -5,12 +5,14 @@ import { makePassThroughMiddleware } from './wallet/PassthroughMiddleware'
 import { makeAuthorizeMiddleware } from './wallet/AuthorizeMiddleware'
 import { makeAccountsMiddleware } from './wallet/AccountsMiddleware'
 import { WalletPermissionSystem } from './wallet/WalletPermissionSystem'
+import { makeSignMessageMiddleware } from './wallet/SignMessageMiddleware'
 
 export function makeRpcEngine({
   debug,
   logger,
   emit,
   providerThunk,
+  walletThunk,
   walletsThunk,
   waitAuthorization,
   wps,
@@ -19,6 +21,7 @@ export function makeRpcEngine({
   emit: (eventName: string, ...args: any[]) => void
   logger?: (message: string) => void
   providerThunk: () => ethers.providers.JsonRpcProvider
+  walletThunk: () => ethers.Wallet
   walletsThunk: () => ethers.Signer[]
   waitAuthorization: (
     req: JsonRpcRequest,
@@ -36,6 +39,7 @@ export function makeRpcEngine({
 
   engine.push(makeAuthorizeMiddleware(waitAuthorization))
   engine.push(makeAccountsMiddleware(emit, walletsThunk, wps))
+  engine.push(makeSignMessageMiddleware(walletThunk))
   engine.push(makePassThroughMiddleware(providerThunk))
 
   return engine

--- a/src/jsonRpcEngine.ts
+++ b/src/jsonRpcEngine.ts
@@ -8,6 +8,7 @@ import { makeAccountsMiddleware } from './wallet/AccountsMiddleware'
 import { WalletPermissionSystem } from './wallet/WalletPermissionSystem'
 import { makeSignMessageMiddleware } from './wallet/SignMessageMiddleware'
 import { makeNetworkMiddleware } from './wallet/NetworkMiddleware'
+import { makeTransactionMiddleware } from './wallet/TransactionMiddleware'
 
 export function makeRpcEngine({
   addNetwork,
@@ -51,6 +52,7 @@ export function makeRpcEngine({
   engine.push(
     makeNetworkMiddleware(currentChainThunk, addNetwork, switchNetwork)
   )
+  engine.push(makeTransactionMiddleware(providerThunk, walletThunk))
   engine.push(makePassThroughMiddleware(providerThunk))
 
   return engine

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,3 +14,8 @@ export interface PendingRequest {
   reject: (err: { message?: string; code?: number }) => void
   authorize: () => Promise<void>
 }
+
+export interface ChainConnection {
+  chainId: number
+  rpcUrl: string
+}

--- a/src/wallet/AccountsMiddleware.ts
+++ b/src/wallet/AccountsMiddleware.ts
@@ -1,0 +1,49 @@
+import {
+  createAsyncMiddleware,
+  type JsonRpcMiddleware,
+} from '@metamask/json-rpc-engine'
+import type { Json, JsonRpcParams } from '@metamask/utils'
+import type { Signer } from 'ethers'
+import { Web3RequestKind } from '../utils'
+import type { WalletPermissionSystem } from './WalletPermissionSystem'
+
+export function makeAccountsMiddleware(
+  emit: (eventName: string, ...args: any[]) => void,
+  walletsThunk: () => Signer[],
+  wps: WalletPermissionSystem
+) {
+  const middleware: JsonRpcMiddleware<JsonRpcParams, Json> =
+    createAsyncMiddleware(async (req, res, next) => {
+      switch (req.method) {
+        case 'eth_accounts':
+          if (wps.isPermitted(Web3RequestKind.Accounts, '')) {
+            res.result = await Promise.all(
+              walletsThunk().map(async (wallet) =>
+                (await wallet.getAddress()).toLowerCase()
+              )
+            )
+          } else {
+            res.result = []
+          }
+          break
+
+        case 'eth_requestAccounts':
+          wps.permit(Web3RequestKind.Accounts, '')
+
+          const accounts = await Promise.all(
+            walletsThunk().map(async (wallet) =>
+              (await wallet.getAddress()).toLowerCase()
+            )
+          )
+
+          emit('accountsChanged', accounts)
+          res.result = accounts
+          break
+
+        default:
+          void next()
+      }
+    })
+
+  return middleware
+}

--- a/src/wallet/NetworkMiddleware.ts
+++ b/src/wallet/NetworkMiddleware.ts
@@ -1,0 +1,59 @@
+import {
+  createAsyncMiddleware,
+  type JsonRpcMiddleware,
+} from '@metamask/json-rpc-engine'
+import type { Json, JsonRpcParams } from '@metamask/utils'
+import type { ChainConnection } from '../types'
+
+export function makeNetworkMiddleware(
+  currentChainThunk: () => ChainConnection,
+  addNetwork: (chainId: number, rpcUrl: string) => void,
+  switchNetwork: (chainId_: number) => void
+) {
+  const middleware: JsonRpcMiddleware<JsonRpcParams, Json> =
+    createAsyncMiddleware(async (req, res, next) => {
+      switch (req.method) {
+        case 'eth_chainId': {
+          const { chainId } = currentChainThunk()
+          res.result = '0x' + chainId.toString(16)
+          break
+        }
+
+        case 'net_version': {
+          const { chainId } = currentChainThunk()
+          res.result = chainId
+          break
+        }
+
+        case 'wallet_addEthereumChain': {
+          // @ts-expect-error todo: parse params
+          const chainId = Number(req.params[0].chainId)
+          // @ts-expect-error todo: parse params
+          const rpcUrl = req.params[0].rpcUrls[0]
+          addNetwork(chainId, rpcUrl)
+
+          res.result = null
+          break
+        }
+
+        case 'wallet_switchEthereumChain': {
+          const { chainId } = currentChainThunk()
+
+          // @ts-expect-error todo: parse params
+          if (chainId !== Number(req.params[0].chainId)) {
+            // @ts-expect-error todo: parse params
+            const chainId = Number(req.params[0].chainId)
+            switchNetwork(chainId)
+          }
+
+          res.result = null
+          break
+        }
+
+        default:
+          void next()
+      }
+    })
+
+  return middleware
+}

--- a/src/wallet/PermissionMiddleware.ts
+++ b/src/wallet/PermissionMiddleware.ts
@@ -1,0 +1,46 @@
+import {
+  createAsyncMiddleware,
+  type JsonRpcMiddleware,
+} from '@metamask/json-rpc-engine'
+import type { Json, JsonRpcParams } from '@metamask/utils'
+import type { Signer } from 'ethers'
+import { Web3RequestKind } from '../utils'
+import type { WalletPermissionSystem } from './WalletPermissionSystem'
+import { Deny } from '../errors'
+
+export function makePermissionMiddleware(
+  emit: (eventName: string, ...args: any[]) => void,
+  walletsThunk: () => Signer[]
+) {
+  const middleware: JsonRpcMiddleware<JsonRpcParams, Json> =
+    createAsyncMiddleware(async (req, res, next) => {
+      switch (req.method) {
+        // todo: use the Wallet Permissions System (WPS) to handle method
+        case 'wallet_requestPermissions': {
+          if (
+            // @ts-expect-error todo: parse params
+            req.params.length === 0 ||
+            // @ts-expect-error todo: parse params
+            req.params[0].eth_accounts === undefined
+          ) {
+            throw Deny()
+          }
+
+          const accounts = await Promise.all(
+            walletsThunk().map(async (wallet) =>
+              (await wallet.getAddress()).toLowerCase()
+            )
+          )
+          emit('accountsChanged', accounts)
+
+          res.result = [{ parentCapability: 'eth_accounts' }]
+          break
+        }
+
+        default:
+          void next()
+      }
+    })
+
+  return middleware
+}

--- a/src/wallet/SignMessageMiddleware.ts
+++ b/src/wallet/SignMessageMiddleware.ts
@@ -1,0 +1,78 @@
+import {
+  createAsyncMiddleware,
+  type JsonRpcMiddleware,
+} from '@metamask/json-rpc-engine'
+import type { Json, JsonRpcParams } from '@metamask/utils'
+import { signTypedData, SignTypedDataVersion } from '@metamask/eth-sig-util'
+import { ethers } from 'ethers'
+import assert from 'node:assert/strict'
+import { toUtf8String } from 'ethers/lib/utils'
+
+export function makeSignMessageMiddleware(walletThunk: () => ethers.Wallet) {
+  const middleware: JsonRpcMiddleware<JsonRpcParams, Json> =
+    createAsyncMiddleware(async (req, res, next) => {
+      switch (req.method) {
+        case 'personal_sign': {
+          const wallet = walletThunk()
+          const address = await wallet.getAddress()
+          // @ts-expect-error todo: parse params
+          assert.equal(address, ethers.utils.getAddress(req.params[1]))
+          // @ts-expect-error todo: parse params
+          const message = toUtf8String(req.params[0])
+
+          const signature = await wallet.signMessage(message)
+
+          res.result = signature
+          break
+        }
+
+        case 'eth_signTypedData':
+        case 'eth_signTypedData_v1': {
+          const wallet = walletThunk()
+          const address = await wallet.getAddress()
+          // @ts-expect-error todo: parse params
+          assert.equal(address, ethers.utils.getAddress(req.params[1]))
+
+          // @ts-expect-error todo: parse params
+          const msgParams = req.params[0]
+
+          const signature = signTypedData({
+            privateKey: Buffer.from(wallet.privateKey.slice(2), 'hex'),
+            data: msgParams,
+            version: SignTypedDataVersion.V1,
+          })
+
+          res.result = signature
+          break
+        }
+
+        case 'eth_signTypedData_v3':
+        case 'eth_signTypedData_v4': {
+          const wallet = walletThunk()
+          const address = await wallet.getAddress()
+          // @ts-expect-error todo: parse params
+          assert.equal(address, ethers.utils.getAddress(req.params[0]))
+
+          // @ts-expect-error todo: parse params
+          const msgParams = JSON.parse(req.params[1])
+
+          const signature = signTypedData({
+            privateKey: Buffer.from(wallet.privateKey.slice(2), 'hex'),
+            data: msgParams,
+            version:
+              req.method === 'eth_signTypedData_v4'
+                ? SignTypedDataVersion.V4
+                : SignTypedDataVersion.V3,
+          })
+
+          res.result = signature
+          break
+        }
+
+        default:
+          void next()
+      }
+    })
+
+  return middleware
+}

--- a/src/wallet/TransactionMiddleware.ts
+++ b/src/wallet/TransactionMiddleware.ts
@@ -1,0 +1,81 @@
+import {
+  createAsyncMiddleware,
+  type JsonRpcMiddleware,
+} from '@metamask/json-rpc-engine'
+import type { Json, JsonRpcParams } from '@metamask/utils'
+import { ethers } from 'ethers'
+
+export function makeTransactionMiddleware(
+  providerThunk: () => ethers.providers.JsonRpcProvider,
+  walletThunk: () => ethers.Wallet
+) {
+  const middleware: JsonRpcMiddleware<JsonRpcParams, Json> =
+    createAsyncMiddleware(async (req, res, next) => {
+      switch (req.method) {
+        case 'eth_sendTransaction': {
+          const wallet = walletThunk()
+          const rpc = providerThunk()
+          // @ts-expect-error todo: parse params
+          const jsonRpcTx = req.params[0]
+
+          const txRequest = convertJsonRpcTxToEthersTxRequest(jsonRpcTx)
+          const tx = await wallet.connect(rpc).sendTransaction(txRequest)
+
+          res.result = tx.hash
+          break
+        }
+
+        default:
+          void next()
+      }
+    })
+
+  return middleware
+}
+
+// Allowed keys for a JSON-RPC transaction as defined in:
+// https://ethereum.github.io/execution-apis/api-documentation/
+const allowedTransactionKeys = [
+  'accessList',
+  'chainId',
+  'data',
+  'from',
+  'gas',
+  'gasPrice',
+  'maxFeePerGas',
+  'maxPriorityFeePerGas',
+  'nonce',
+  'to',
+  'type',
+  'value',
+]
+
+// Convert a JSON-RPC transaction to an ethers.js transaction.
+// The reverse of this function can be found in the ethers.js library:
+// https://github.com/ethers-io/ethers.js/blob/v5.7.2/packages/providers/src.ts/json-rpc-provider.ts#L701
+function convertJsonRpcTxToEthersTxRequest(tx: {
+  [key: string]: any
+}): ethers.providers.TransactionRequest {
+  const result: any = {}
+
+  allowedTransactionKeys.forEach((key) => {
+    if (tx[key] == null) {
+      return
+    }
+
+    switch (key) {
+      // gasLimit is referred to as "gas" in JSON-RPC
+      case 'gas':
+        result['gasLimit'] = tx[key]
+        return
+      // ethers.js expects `chainId` and `type` to be a number
+      case 'chainId':
+      case 'type':
+        result[key] = Number(tx[key])
+        return
+      default:
+        result[key] = tx[key]
+    }
+  })
+  return result
+}


### PR DESCRIPTION
Follow up of https://github.com/cawabunga/headless-web3-provider/pull/19

All methods are migrated to middlewares.