### PR TITLE
Fix a bug causing `toUtf8String` to be called twice

### DIFF
--- a/src/wallet/SignMessageMiddleware.ts
+++ b/src/wallet/SignMessageMiddleware.ts
@@ -18,7 +18,7 @@ export function makeSignMessageMiddleware(walletThunk: () => ethers.Wallet) {
           // @ts-expect-error todo: parse params
           assert.equal(address, ethers.utils.getAddress(req.params[1]))
           // @ts-expect-error todo: parse params
-          const message = toUtf8String(req.params[0])
+          const message = req.params[0];
 
           const signature = await wallet.signMessage(message)
 


### PR DESCRIPTION
@cawabunga  We found a bug when we call `personal_sign` as follows:

```sh
Error: invalid codepoint at offset 1; unexpected continuation byte (argument="bytes", value=Uint8Array(0x6ab6f86fe030047196dfe6323700b9659e5b4c92ba19aa7f89625ab8d621879e), code=INVALID_ARGUMENT, version=strings/5.7.0)
```

`await wallet.signMessage(message)` is calling `toUtf8String()` internally so we don't need to call it before calling `signMessage()`.